### PR TITLE
feat: 진행중인 미션 진행 완료로 바꾸기 API 구현

### DIFF
--- a/src/main/java/org/umc/spring/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/org/umc/spring/apiPayload/code/status/ErrorStatus.java
@@ -29,6 +29,8 @@ public enum ErrorStatus implements BaseErrorCode {
 
     MISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "MISSION4001", "미션을 찾을 수 없습니다."),
     MISSION_ALREADY_CHALLENGED(HttpStatus.BAD_REQUEST, "MISSION4002", "이미 도전 중인 미션입니다."),
+    MISSION_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "MISSION4003", "이미 완료된 미션입니다."),
+    MEMBER_MISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "MISSION4004", "해당 회원의 미션을 찾을 수 없습니다."),
 
     // 조회 관련 에러
     PAGE_NUMBER_ERROR(HttpStatus.BAD_REQUEST, "PAGE4001", "페이지 번호는 1 이상이어야 합니다."),

--- a/src/main/java/org/umc/spring/controller/MissionController.java
+++ b/src/main/java/org/umc/spring/controller/MissionController.java
@@ -1,13 +1,24 @@
 package org.umc.spring.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.umc.spring.apiPayload.ApiResponse;
+import org.umc.spring.apiPayload.code.status.ErrorStatus;
+import org.umc.spring.apiPayload.exception.handler.PageHandler;
 import org.umc.spring.converter.MemberMissionConverter;
+import org.umc.spring.domain.enums.MissionStatus;
 import org.umc.spring.domain.mapping.MemberMission;
 import org.umc.spring.dto.membermission.response.MemberMissionResponseDTO;
 import org.umc.spring.service.MissionService.MissionCommandService;
+import org.umc.spring.service.MissionService.MissionQueryService;
+import org.umc.spring.validation.annotation.CheckPage;
 import org.umc.spring.validation.annotation.ExistMission;
 
 @RestController
@@ -17,8 +28,17 @@ import org.umc.spring.validation.annotation.ExistMission;
 public class MissionController {
 
     private final MissionCommandService missionCommandService;
+    private final MissionQueryService missionQueryService;
 
     @PostMapping("/{missionId}/member-missions")
+    @Operation(summary = "미션 도전 API", description = "특정 미션에 도전하는 API입니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH004", description = "access 토큰 만료", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "MISSION4001", description = "미션을 찾을 수 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "MISSION4002", description = "이미 도전 중인 미션입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    })
     public ApiResponse<MemberMissionResponseDTO.CreateResultDTO> challengeMission(
             @PathVariable @ExistMission Long missionId,
             @RequestHeader("X-AUTH-ID") Long memberId
@@ -26,4 +46,49 @@ public class MissionController {
         MemberMission memberMission = missionCommandService.challengeMission(missionId, memberId);
         return ApiResponse.onSuccess(MemberMissionConverter.toCreateResultDTO(memberMission));
     }
+
+    @PatchMapping("/{missionId}/complete")
+    @Operation(summary = "미션 완료 API", description = "진행 중인 미션을 완료 상태로 변경하는 API입니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH004", description = "access 토큰 만료", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "MISSION4001", description = "미션을 찾을 수 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "MISSION4003", description = "이미 완료된 미션입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "MISSION4004", description = "해당 회원의 미션을 찾을 수 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    })
+    public ApiResponse<MemberMissionResponseDTO.CompleteResultDTO> completeMission(
+            @Parameter(description = "완료할 미션의 ID")
+            @PathVariable @ExistMission Long missionId,
+            @RequestHeader("X-AUTH-ID") Long memberId
+    ) {
+        MemberMission memberMission = missionCommandService.completeMission(missionId, memberId);
+        return ApiResponse.onSuccess(MemberMissionConverter.toCompleteResultDTO(memberMission));
+    }
+
+    @GetMapping("/my-missions")
+    @Operation(summary = "내 미션 목록 조회 API", description = "내가 진행중인 미션 목록을 조회하는 API이며, 페이징을 포함합니다. query String으로 page 번호를 주세요.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH004", description = "access 토큰 만료", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "PAGE4001", description = "페이지 번호는 1 이상이어야 합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "PAGE4002", description = "해당 페이지에 데이터가 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    })
+    public ApiResponse<MemberMissionResponseDTO.MemberMissionListDTO> getMyMissions(
+            @RequestHeader("X-AUTH-ID") Long memberId,
+            @Parameter(description = "페이지 번호(1부터 시작)")
+            @RequestParam @CheckPage Integer page
+    ) {
+        // 1부터 시작하는 페이지 번호를 0부터 시작하는 인덱스로 변환
+        Page<MemberMission> missionPage = missionQueryService.getMyMissions(memberId, MissionStatus.CHALLENGE, page - 1);
+
+        // 페이지가 비어있을 경우 예외 처리
+        if(missionPage.isEmpty()) {
+            throw new PageHandler(ErrorStatus.PAGE_NO_DATA);
+        }
+
+        return ApiResponse.onSuccess(MemberMissionConverter.toMemberMissionListDTO(missionPage));
+    }
 }
+

--- a/src/main/java/org/umc/spring/converter/MemberMissionConverter.java
+++ b/src/main/java/org/umc/spring/converter/MemberMissionConverter.java
@@ -1,7 +1,11 @@
 package org.umc.spring.converter;
 
+import org.springframework.data.domain.Page;
 import org.umc.spring.domain.mapping.MemberMission;
 import org.umc.spring.dto.membermission.response.MemberMissionResponseDTO;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class MemberMissionConverter {
 
@@ -14,4 +18,44 @@ public class MemberMissionConverter {
                 .createdAt(memberMission.getCreatedAt())
                 .build();
     }
+
+    public static MemberMissionResponseDTO.CompleteResultDTO toCompleteResultDTO(MemberMission memberMission) {
+        return MemberMissionResponseDTO.CompleteResultDTO.builder()
+                .id(memberMission.getId())
+                .missionId(memberMission.getMission().getId())
+                .memberId(memberMission.getMember().getId())
+                .status(memberMission.getStatus())
+                .updatedAt(memberMission.getUpdatedAt())
+                .rewardPoints(memberMission.getMission().getRewardPoints())
+                .build();
+    }
+
+    public static MemberMissionResponseDTO.MemberMissionPreviewDTO toMemberMissionPreviewDTO(MemberMission memberMission) {
+        return MemberMissionResponseDTO.MemberMissionPreviewDTO.builder()
+                .id(memberMission.getId())
+                .missionId(memberMission.getMission().getId())
+                .missionSpec(memberMission.getMission().getMissionSpec())
+                .status(memberMission.getStatus())
+                .rewardPoints(memberMission.getMission().getRewardPoints())
+                .storeName(memberMission.getMission().getStore().getName())
+                .challengedAt(memberMission.getCreatedAt())
+                .completedAt(memberMission.getUpdatedAt())
+                .build();
+    }
+
+    public static MemberMissionResponseDTO.MemberMissionListDTO toMemberMissionListDTO(Page<MemberMission> missionPage) {
+        List<MemberMissionResponseDTO.MemberMissionPreviewDTO> missionPreviewList = missionPage.stream()
+                .map(MemberMissionConverter::toMemberMissionPreviewDTO)
+                .collect(Collectors.toList());
+
+        return MemberMissionResponseDTO.MemberMissionListDTO.builder()
+                .missionList(missionPreviewList)
+                .listSize(missionPreviewList.size())
+                .totalPage(missionPage.getTotalPages())
+                .totalElements(missionPage.getTotalElements())
+                .isFirst(missionPage.isFirst())
+                .isLast(missionPage.isLast())
+                .build();
+    }
 }
+

--- a/src/main/java/org/umc/spring/domain/mapping/MemberMission.java
+++ b/src/main/java/org/umc/spring/domain/mapping/MemberMission.java
@@ -46,4 +46,9 @@ public class MemberMission extends BaseEntity {
         }
         this.mission = mission;
     }
+
+    public void updateStatus(MissionStatus status) {
+        this.status = status;
+    }
 }
+

--- a/src/main/java/org/umc/spring/dto/membermission/response/MemberMissionResponseDTO.java
+++ b/src/main/java/org/umc/spring/dto/membermission/response/MemberMissionResponseDTO.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import org.umc.spring.domain.enums.MissionStatus;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class MemberMissionResponseDTO {
 
@@ -21,4 +22,46 @@ public class MemberMissionResponseDTO {
         private MissionStatus status;
         private LocalDateTime createdAt;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CompleteResultDTO {
+        private Long id;
+        private Long missionId;
+        private Long memberId;
+        private MissionStatus status;
+        private LocalDateTime updatedAt;
+        private Integer rewardPoints;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MemberMissionPreviewDTO {
+        private Long id;
+        private Long missionId;
+        private String missionSpec;
+        private MissionStatus status;
+        private Integer rewardPoints;
+        private String storeName;
+        private LocalDateTime challengedAt;
+        private LocalDateTime completedAt;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MemberMissionListDTO {
+        private List<MemberMissionPreviewDTO> missionList;
+        private Integer listSize;
+        private Integer totalPage;
+        private Long totalElements;
+        private Boolean isFirst;
+        private Boolean isLast;
+    }
 }
+

--- a/src/main/java/org/umc/spring/repository/MemberMissionRepository/MemberMissionRepository.java
+++ b/src/main/java/org/umc/spring/repository/MemberMissionRepository/MemberMissionRepository.java
@@ -1,8 +1,16 @@
 package org.umc.spring.repository.MemberMissionRepository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.umc.spring.domain.enums.MissionStatus;
 import org.umc.spring.domain.mapping.MemberMission;
+
+import java.util.Optional;
 
 public interface MemberMissionRepository extends JpaRepository<MemberMission, Long>, MemberMissionRepositoryCustom {
     boolean existsByMissionIdAndMemberId(Long missionId, Long memberId);
+    Optional<MemberMission> findByMissionIdAndMemberId(Long missionId, Long memberId);
+    Page<MemberMission> findAllByMemberIdAndStatus(Long memberId, MissionStatus status, Pageable pageable);
 }
+

--- a/src/main/java/org/umc/spring/service/MissionService/MissionCommandService.java
+++ b/src/main/java/org/umc/spring/service/MissionService/MissionCommandService.java
@@ -4,4 +4,6 @@ import org.umc.spring.domain.mapping.MemberMission;
 
 public interface MissionCommandService {
     MemberMission challengeMission(Long missionId, Long memberId);
+    MemberMission completeMission(Long missionId, Long memberId);
 }
+

--- a/src/main/java/org/umc/spring/service/MissionService/MissionCommandServiceImpl.java
+++ b/src/main/java/org/umc/spring/service/MissionService/MissionCommandServiceImpl.java
@@ -51,4 +51,30 @@ public class MissionCommandServiceImpl implements MissionCommandService {
         // 저장 및 반환
         return memberMissionRepository.save(memberMission);
     }
+
+    @Override
+    public MemberMission completeMission(Long missionId, Long memberId) {
+        // 미션은 이미 컨트롤러에서 @ExistMission으로 검증되었으므로 바로 조회
+        Mission mission = missionRepository.findById(missionId).get();
+
+        // 회원 존재 확인
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        // 해당 회원의 해당 미션이 존재하는지 확인
+        MemberMission memberMission = memberMissionRepository.findByMissionIdAndMemberId(missionId, memberId)
+                .orElseThrow(() -> new MissionHandler(ErrorStatus.MISSION_NOT_FOUND));
+
+        // 이미 완료된 미션인지 확인
+        if (MissionStatus.COMPLETE.equals(memberMission.getStatus())) {
+            throw new MissionHandler(ErrorStatus.MISSION_ALREADY_COMPLETED);
+        }
+
+        // 미션 상태 변경
+        memberMission.updateStatus(MissionStatus.COMPLETE);
+
+        // 저장 및 반환
+        return memberMissionRepository.save(memberMission);
+    }
 }
+

--- a/src/main/java/org/umc/spring/service/MissionService/MissionQueryService.java
+++ b/src/main/java/org/umc/spring/service/MissionService/MissionQueryService.java
@@ -3,11 +3,14 @@ package org.umc.spring.service.MissionService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Slice;
 import org.umc.spring.domain.Mission;
+import org.umc.spring.domain.enums.MissionStatus;
+import org.umc.spring.domain.mapping.MemberMission;
 import org.umc.spring.dto.mission.response.MissionResponseDTO;
 
 public interface MissionQueryService {
     Slice<MissionResponseDTO> loadHomeMissions(Long memberId);
     boolean existsById(Long id);
     Page<Mission> getStoreAllMissions(Long storeId, Integer page);
+    Page<MemberMission> getMyMissions(Long memberId, MissionStatus status, Integer page);
 }
 

--- a/src/main/java/org/umc/spring/service/MissionService/MissionQueryServiceImpl.java
+++ b/src/main/java/org/umc/spring/service/MissionService/MissionQueryServiceImpl.java
@@ -12,7 +12,10 @@ import org.umc.spring.apiPayload.code.status.ErrorStatus;
 import org.umc.spring.apiPayload.exception.handler.StoreHandler;
 import org.umc.spring.domain.Mission;
 import org.umc.spring.domain.Store;
+import org.umc.spring.domain.enums.MissionStatus;
+import org.umc.spring.domain.mapping.MemberMission;
 import org.umc.spring.dto.mission.response.MissionResponseDTO;
+import org.umc.spring.repository.MemberMissionRepository.MemberMissionRepository;
 import org.umc.spring.repository.MissionRepository.MissionRepository;
 import org.umc.spring.service.StoreService.StoreQueryService;
 
@@ -25,6 +28,7 @@ public class MissionQueryServiceImpl implements MissionQueryService {
 
     private final MissionRepository missionRepository;
     private final StoreQueryService storeQueryService;
+    private final MemberMissionRepository memberMissionRepository;
 
     @Override
     public Slice<MissionResponseDTO> loadHomeMissions(Long memberId) {
@@ -53,5 +57,13 @@ public class MissionQueryServiceImpl implements MissionQueryService {
         // 가게별 미션 목록 조회
         return missionRepository.findAllByStore(store, pageRequest);
     }
-}
 
+    @Override
+    public Page<MemberMission> getMyMissions(Long memberId, MissionStatus status, Integer page) {
+        // 페이징 처리 (10개씩)
+        PageRequest pageRequest = PageRequest.of(page, 10);
+
+        // 회원별, 상태별 미션 목록 조회
+        return memberMissionRepository.findAllByMemberIdAndStatus(memberId, status, pageRequest);
+    }
+}


### PR DESCRIPTION
- MemberMission 엔티티에 상태 업데이트 메서드(updateStatus) 추가
- 미션 완료 API (PATCH /missions/{missionId}/complete) 구현
- 진행 중인 미션 목록 조회 API (GET /missions/my-missions) 구현
- MissionCommandService/Impl에 미션 완료 관련 비즈니스 로직 추가
- MemberMissionRepository에 회원/상태별 미션 조회 메서드 추가
- DTO 및 Converter 클래스에 Stream API를 활용한 데이터 변환 로직 구현
- ErrorStatus에 미션 완료 관련 에러 코드(MISSION_ALREADY_COMPLETED 등) 추가
- 페이지네이션 처리 (한 페이지당 10개 미션)
- Swagger 문서화 적용
- @CheckPage 어노테이션을 통한 페이지 번호 검증