### PR TITLE
refactor: 내가 작성한 리뷰 목록 조회 API 최적화 (Page → Slice)

### DIFF
--- a/src/main/java/org/umc/spring/controller/MemberController.java
+++ b/src/main/java/org/umc/spring/controller/MemberController.java
@@ -7,7 +7,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Slice;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.umc.spring.apiPayload.ApiResponse;
@@ -52,13 +52,14 @@ public class MemberController {
             @Parameter(description = "페이지 번호(1부터 시작)")
             @RequestParam @CheckPage Integer page
     ) {
-        Page<Review> reviewPage = reviewQueryService.getMyReviews(memberId, page - 1);
+        Slice<Review> reviewSlice = reviewQueryService.getMyReviews(memberId, page - 1);
 
         // 페이지가 비어있을 경우 예외 처리
-        if(reviewPage.isEmpty()) {
+        if(reviewSlice.isEmpty()) {
             throw new PageHandler(ErrorStatus.PAGE_NO_DATA);
         }
 
-        return ApiResponse.onSuccess(ReviewConverter.toMyReviewListDTO(reviewPage));
+        return ApiResponse.onSuccess(ReviewConverter.toMyReviewListDTO(reviewSlice));
     }
 }
+

--- a/src/main/java/org/umc/spring/converter/ReviewConverter.java
+++ b/src/main/java/org/umc/spring/converter/ReviewConverter.java
@@ -1,6 +1,6 @@
 package org.umc.spring.converter;
 
-import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Slice;
 import org.umc.spring.domain.Review;
 import org.umc.spring.domain.enums.ReviewStatus;
 import org.umc.spring.dto.review.request.ReviewRequestDTO;
@@ -45,18 +45,19 @@ public class ReviewConverter {
                 .build();
     }
 
-    public static ReviewResponseDTO.MyReviewListDTO toMyReviewListDTO(Page<Review> reviewPage) {
-        List<ReviewResponseDTO.MyReviewPreviewDTO> reviewPreviewList = reviewPage.stream()
+    public static ReviewResponseDTO.MyReviewListDTO toMyReviewListDTO(Slice<Review> reviewSlice) {
+        List<ReviewResponseDTO.MyReviewPreviewDTO> reviewPreviewList = reviewSlice.stream()
                 .map(ReviewConverter::toMyReviewPreviewDTO)
                 .collect(Collectors.toList());
 
         return ReviewResponseDTO.MyReviewListDTO.builder()
                 .reviewList(reviewPreviewList)
                 .listSize(reviewPreviewList.size())
-                .totalPage(reviewPage.getTotalPages())
-                .totalElements(reviewPage.getTotalElements())
-                .isFirst(reviewPage.isFirst())
-                .isLast(reviewPage.isLast())
+                .totalPage(null) // Slice에서는 전체 페이지 수를 알 수 없음
+                .totalElements(null) // Slice에서는 전체 요소 수를 알 수 없음
+                .isFirst(reviewSlice.isFirst())
+                .isLast(reviewSlice.isLast())
+                .hasNext(reviewSlice.hasNext()) // hasNext 추가
                 .build();
     }
 }

--- a/src/main/java/org/umc/spring/dto/review/response/ReviewResponseDTO.java
+++ b/src/main/java/org/umc/spring/dto/review/response/ReviewResponseDTO.java
@@ -46,5 +46,6 @@ public class ReviewResponseDTO {
         private Long totalElements;
         private Boolean isFirst;
         private Boolean isLast;
+        private Boolean hasNext; // 다음 페이지 존재 여부 표시 필드 추가
     }
 }

--- a/src/main/java/org/umc/spring/repository/ReviewRepository/ReviewRepository.java
+++ b/src/main/java/org/umc/spring/repository/ReviewRepository/ReviewRepository.java
@@ -2,6 +2,8 @@ package org.umc.spring.repository.ReviewRepository;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.umc.spring.domain.Review;
 import org.umc.spring.domain.Store;
@@ -9,4 +11,5 @@ import org.umc.spring.domain.Store;
 public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewRepositoryCustom {
     Page<Review> findAllByStore(Store store, PageRequest pageRequest);
     Page<Review> findAllByMemberId(Long memberId, PageRequest pageRequest);
+    Slice<Review> findSliceAllByMemberId(Long memberId, Pageable pageable);
 }

--- a/src/main/java/org/umc/spring/service/ReviewService/ReviewQueryService.java
+++ b/src/main/java/org/umc/spring/service/ReviewService/ReviewQueryService.java
@@ -1,8 +1,9 @@
 package org.umc.spring.service.ReviewService;
 
-import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Slice;
 import org.umc.spring.domain.Review;
 
 public interface ReviewQueryService {
-    Page<Review> getMyReviews(Long memberId, Integer page);
+    Slice<Review> getMyReviews(Long memberId, Integer page);
 }
+

--- a/src/main/java/org/umc/spring/service/ReviewService/ReviewQueryServiceImpl.java
+++ b/src/main/java/org/umc/spring/service/ReviewService/ReviewQueryServiceImpl.java
@@ -1,8 +1,8 @@
 package org.umc.spring.service.ReviewService;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.umc.spring.domain.Review;
@@ -16,7 +16,8 @@ public class ReviewQueryServiceImpl implements ReviewQueryService {
     private final ReviewRepository reviewRepository;
 
     @Override
-    public Page<Review> getMyReviews(Long memberId, Integer page) {
-        return reviewRepository.findAllByMemberId(memberId, PageRequest.of(page, 10));
+    public Slice<Review> getMyReviews(Long memberId, Integer page) {
+        return reviewRepository.findSliceAllByMemberId(memberId, PageRequest.of(page, 10));
     }
 }
+


### PR DESCRIPTION
- 리뷰 목록 조회 시 Page에서 Slice로 변경하여 쿼리 성능 개선
- ReviewRepository에 Slice 타입 반환을 위한 findSliceAllByMemberId 메서드 추가
- ReviewResponseDTO.MyReviewListDTO에 hasNext 필드 추가하여 다음 페이지 여부 표시
- ReviewConverter.toMyReviewListDTO 메서드가 Slice 객체를 처리하도록 수정
- 전체 페이지 수와 전체 요소 수 필드는 불필요하여 null로 설정
- MemberController에서 Slice 객체를 활용한 페이지네이션 처리