### PR TITLE
feat: develop 브랜치에 PR merge 시 자동 배포되는 CI/CD 워크플로우 추가 #34

### DIFF
--- a/workflows/dev_deploy.yml
+++ b/workflows/dev_deploy.yml
@@ -1,0 +1,11 @@
+name: UMC Dev CI/CD
+
+on:
+  pull_request:
+    types: [closed]
+    branches: ['develop']
+  workflow_dispatch: # (2).수동 실행도 가능하도록
+
+jobs:
+  build:
+    runs-on: ubuntu-latest # (3).OS환경


### PR DESCRIPTION
- PR이 develop 브랜치에 merge된 경우에만 배포 워크플로우 실행
- 워크플로우 수동 실행 옵션 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - 새로운 GitHub Actions 워크플로우가 추가되어, PR이 `develop` 브랜치로 병합되거나 수동으로 실행될 때 자동으로 빌드 작업이 수행됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->