### PR TITLE
build: spring-context 의존성 추가 및 테스트 재시도 로직 추가 #34

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,7 @@ dependencies {
 
 	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework:spring-context'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
@@ -94,4 +95,13 @@ tasks.withType(JavaCompile) {
 			'--add-opens',
 			'java.base/java.util=ALL-UNNAMED'
 	]
+}
+
+gradle.taskGraph.whenReady {
+	tasks.withType(Test).configureEach {
+		retry {
+			maxRetries = 3
+			maxFailures = 10
+		}
+	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
  - 테스트 의존성으로 `org.springframework:spring-context`가 추가되었습니다.
  - 모든 테스트 작업에 대해 최대 3회 재시도 및 최대 10번 실패 시 중단되는 테스트 재시도 설정이 적용되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->